### PR TITLE
products stores are getting deleted when updating

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -1,5 +1,4 @@
 Spree::Admin::ProductsController.class_eval do
-  update.before :set_stores
 
   def update
     store_ids = params[:product][:store_ids]
@@ -7,11 +6,5 @@ Spree::Admin::ProductsController.class_eval do
       params[:product][:store_ids] = store_ids.split(',')
     end
     super
-  end
-
-  private
-
-  def set_stores
-    @product.store_ids = nil unless params[:product].key? :store_ids
   end
 end

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -16,13 +16,14 @@ describe Spree::Admin::ProductsController do
       @store = FactoryGirl.create(:store)
     end
 
-    describe "when no stores are selected" do
+    describe "when stores is an empty string" do
       it "clears stores if they previously existed" do
         @product.stores << @store
         spree_put :update,
           id: @product.to_param,
           product: {
-            name: @product.name
+            name: @product.name,
+            store_ids: ''
           }
 
         expect(@product.reload.store_ids).to be_empty


### PR DESCRIPTION
This PR deletes the `before update` callback because opening the update method in `Spree::Admin::ProductsController` is enough. I also changed the test to reflect the new behaviour.

This works because `store_ids` is an attribute of the Product so the UI will try to update it always with a valid value if updating the product details, or it won't be present in the request when editing other than details

<img width="1440" alt="screen shot 2017-03-21 at 18 37 57" src="https://cloud.githubusercontent.com/assets/3480612/24164508/ddb0e296-0e65-11e7-80a6-a5bf3c1f451e.png">

